### PR TITLE
DWT-2202: add override url for easier local docker configuartion

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -198,6 +198,13 @@ const config = convict({
     }
   },
   oidc: {
+    baseUrl: {
+      doc: 'Application base URL for OIDC config if different from APP_BASE_URL',
+      format: String,
+      default: null,
+      nullable: true,
+      env: 'OIDC_APP_BASE_URL'
+    },
     basePath: {
       doc: 'the base path all oidc stubs will be served from',
       format: String,

--- a/src/server/oidc/controllers/well-known-openid-configuration.js
+++ b/src/server/oidc/controllers/well-known-openid-configuration.js
@@ -1,7 +1,7 @@
 import { config } from '~/src/config/index.js'
 import { oidcConfig } from '~/src/server/oidc/oidc-config.js'
 
-const appBaseUrl = config.get('appBaseUrl')
+const appBaseUrl = config.get('oidc.baseUrl') || config.get('appBaseUrl')
 
 const appOidcConfig = {
   issuer: appBaseUrl + oidcConfig.issuerBase,


### PR DESCRIPTION
Add config option to allow override of the APP_BASE_URL for discovery endpoint for use when running locally in docker-compose. 